### PR TITLE
Fix random layout changes in MacOS Monterey

### DIFF
--- a/BEPO-ISO.bundle/Contents/Resources/BEPO - ISO.keylayout
+++ b/BEPO-ISO.bundle/Contents/Resources/BEPO - ISO.keylayout
@@ -4,8 +4,12 @@
 <!-- http://www.bepo.fr/ -->
 <!-- version 1.1rc2 -->
 <!--Last edited by Ukelele version 3.2.0.154 on 2019-04-30 at 12:10 (UTC+2)-->
-<keyboard group="126" id="-32245" name="BEPO - ISO" maxout="2">
-	<!--
+
+<!-- The following line was edited following https://superuser.com/a/1741104/
+    to prevent random layout changes in Mac OS Monterey
+-->
+<keyboard group="0" id="16003" name="BEPO - ISO" maxout="1">
+  <!--
     This layout is designed for ISO keyboards ONLY. The extra
     key on an ISO keyboard (next to the left Shift) is optional,
     characters on it are also accessible through other keys.


### PR DESCRIPTION
Le passage à Monterey s’est accompagné de l’impossibilité de ne garder que ce seul clavier BÉPO dans la liste des layouts disponibles (il faut en garder au moins un "officiel", comme AZERTY), et d’incessants (plusieurs fois par jour) basculements imprévisibles et autoritaires vers l’autre layout, tout au long de la journée.

Après quelques mois à  subir cette situation, j’ai trouvé que la solution donnée ici : https://superuser.com/a/1741104/ fonctionnait très bien pour résoudre ce second problème, et ne devrait pas impacter l’utilisation sur les autres versions de Mac. D’où cette proposition de PR !